### PR TITLE
Manifests for setting up a development environment

### DIFF
--- a/manifests/00-megatron-pvc.yaml
+++ b/manifests/00-megatron-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: megatron-dev
+spec:
+  storageClassName: shared-nvme-las1
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Ti

--- a/manifests/01-dataset-download.yaml
+++ b/manifests/01-dataset-download.yaml
@@ -9,7 +9,7 @@ spec:
       - name: megatron-dataset-downloader
         image: alpine/git:2.40.1
         imagePullPolicy: IfNotPresent
-        command: ["bash", "-c"]
+        command: ["/bin/sh", "-c"]
         args:
         - |
           cd /mnt/pvc

--- a/manifests/01-dataset-download.yaml
+++ b/manifests/01-dataset-download.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: megatron-dataset-download
+spec:
+  template:
+    spec:
+      containers:
+      - name: megatron-dataset-downloader
+        image: alpine/git:2.40.1
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+        - |
+          cd /mnt/pvc
+          git clone https://huggingface.co/datasets/hakurei/megatron-dev-dataset
+          git clone -b amercurio/manifests https://github.com/coreweave/coreweave-megatron
+        volumeMounts:
+          - name: megatron-dev
+            mountPath: /mnt/pvc
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi 
+          limits:
+            cpu: 1
+            memory: 1Gi 
+      volumes:
+        - name: megatron-dev
+          persistentVolumeClaim:
+            claimName: megatron-dev
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/region
+                operator: In
+                values: 
+                - LAS1
+      restartPolicy: Never
+  backoffLimit: 2

--- a/manifests/02-ssh-service.yaml
+++ b/manifests/02-ssh-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: megatron-ssh
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+    - name: sshd
+      port: 22
+      protocol: TCP
+      targetPort: sshd
+  selector:
+    app.kubernetes.io/name: megatron-ssh

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,0 +1,95 @@
+# CoreWeave-Megatron Development Manifests
+
+This directory contains Kubernetes manifests and commands to set up a remote development environment
+for running Megatron.
+
+Using these, you may:
+
+- Set up a Persistent Volume Claim (PVC) to hold testing datasets and modified versions of Megatron code
+  for Kubernetes Pods to access
+- Download testing datasets and clone repositories to the PVC
+- Launch one-off training runs as Kubernetes *Jobs*
+- Allocate a Kubernetes Pod as an SSH host to rapidly test changes with many single-node runs,
+  or to debug interactively
+    - This also allows easier access to deploy code updates onto the PVC.
+
+## Preliminary Setup
+
+> 🛈 These commands need only ever be run once, as prerequisites for launching later Pods.
+
+### Persistent Volume Claim for Testing Data
+
+First, set up a PVC (`megatron-pvc`) to house custom data for testing Megatron:
+
+```bash
+kubectl apply -f 00-megatron-pvc.yaml
+```
+
+### Download Testing Data
+
+Then, start a Job to download an example dataset
+[from here](https://huggingface.co/datasets/hakurei/megatron-dev-dataset)
+and clone the CoreWeave Megatron fork to the PVC:
+
+```bash
+kubectl apply -f 01-dataset-download.yaml
+```
+
+### Usage
+
+From here, continue to either the [One-Off Training Runs](#one-off-training-runs) or [SSH Pod](#ssh-pod) sections,
+as appropriate.
+
+## One-Off Training Runs
+
+These manifests allow you to launch one-off training runs as Kubernetes *Jobs*.
+
+> 🛈 Follow the instructions under [Preliminary Setup](#preliminary-setup) before continuing with this section.
+
+### On a Single Node
+
+Pre-train a 345M GPT model from scratch against the example dataset downloaded in the
+[Download Testing Data](#download-testing-data) section by applying the following Kubernetes Job manifest:
+
+```bash
+kubectl apply -f single-node-trainer.yaml
+```
+
+Checkpoints are recorded in the PVC under the `checkpoints/` directory.
+
+### On Multiple Nodes
+
+> ⚠ Work in Progress
+
+## SSH Pod
+
+This section deploys an SSH server container that may be used for single-node interactive testing and development.
+
+Notes:
+
+- Only the `megatron-pvc` mount holds persistent data by default
+- The entire configuration of the SSH server happens on pod startup in the deployment definition
+    - This means starting up the server takes a minute longer, but does not require a base image customized for SSH use
+
+> 🛈 Follow the instructions under [Preliminary Setup](#preliminary-setup) before continuing with this section.
+
+To deploy the container, execute the following commands from this directory:
+
+1. `kubectl apply -f 02-ssh-service.yaml`
+    - Creates a Kubernetes Service to provide the IP address for connecting to the SSH Pod
+2. `bash init-ssh-host-secret.sh`
+    - Creates a Kubernetes Secret to deploy `ssh_host_ed25519_key` and `authorized_keys` files
+3. `bash replace-ssh-authorized-keys.sh ~/.ssh/id_rsa.pub`
+    - **Use a public key or pre-existing `authorized_keys` file of your choice here** in place of `~/.ssh/id_rsa.pub`
+    - Configures the `root` user's `authorized_keys` file on Pod startup
+    - Restart the Pod to apply changes to this setting
+4. `kubectl apply -f ssh-node.yaml`
+    - Launches the SSH Pod as a Kubernetes Deployment
+5. `kubectl get service/megatron-ssh`
+    - Shows the IP address for the SSH server
+    - Use the value shown in the "`EXTERNAL-IP`" field to connect
+6. `ssh root@X.X.X.X`
+    - Connects to the node
+    - Use the `EXTERNAL-IP` from the previous step in place of `X.X.X.X`
+
+To shut down the SSH server, run `kubectl delete deployment/megatron-ssh`.

--- a/manifests/init-ssh-host-secret.sh
+++ b/manifests/init-ssh-host-secret.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+make-secret() {
+  kubectl create secret generic ssh-host-config-1 --from-file=$1;
+}
+
+mkfifo ./ssh_host_ed25519_key_1 && \
+  { { make-secret ./ssh_host_ed25519_key_1; rm ./ssh_host_ed25519_key_1; } & } && \
+  { echo y | ssh-keygen -t ed25519 -N '' -q -f ./ssh_host_ed25519_key_1 > /dev/null; } || \
+  rm ./ssh_host_ed25519_key_1;

--- a/manifests/replace-ssh-authorized-keys.sh
+++ b/manifests/replace-ssh-authorized-keys.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+kubectl get secret ssh-host-config -o json \
+  | jq --arg authorized_keys "$(base64 -w0 < $1)" \
+    '.data["authorized_keys"]=$authorized_keys' \
+  | kubectl apply -f -;

--- a/manifests/single-node-trainer.yaml
+++ b/manifests/single-node-trainer.yaml
@@ -7,9 +7,9 @@ spec:
     spec:
       containers:
       - name: megatron-train
-        image: nvcr.io/nvidia/pytorch:23.05-py3
+        image: nvcr.io/nvidia/pytorch:23.06-py3
         imagePullPolicy: IfNotPresent
-        command: ["bash", "-c", "/mnt/pvc/Megatron-LM/pretrain_single_node.sh"]
+        command: ["bash", "-c", "cd /mnt/pvc/coreweave-megatron && ./pretrain_single_node.sh"]
         tty: true
         securityContext:
           runAsUser: 0
@@ -46,6 +46,6 @@ spec:
               - key: gpu.nvidia.com/class
                 operator: In
                 values:
-                - A100_NVLINK_80GB
+                - A40
       restartPolicy: Never
   backoffLimit: 2

--- a/manifests/single-node-trainer.yaml
+++ b/manifests/single-node-trainer.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: megatron-train-job-single-node
+spec:
+  template:
+    spec:
+      containers:
+      - name: megatron-train
+        image: nvcr.io/nvidia/pytorch:23.05-py3
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c", "/mnt/pvc/Megatron-LM/pretrain_single_node.sh"]
+        tty: true
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+          - name: megatron-dev
+            mountPath: /mnt/pvc
+          - name: dshm
+            mountPath: /dev/shm
+        resources:
+          requests:
+            cpu: 32
+            memory: 512Gi
+            nvidia.com/gpu: 8
+          limits:
+            cpu: 32
+            memory: 512Gi 
+            nvidia.com/gpu: 8
+      volumes:
+        - name: megatron-dev
+          persistentVolumeClaim:
+            claimName: megatron-dev
+        - emptyDir:
+            medium: Memory
+          name: dshm
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/region
+                operator: In
+                values: 
+                - LAS1
+              - key: gpu.nvidia.com/class
+                operator: In
+                values:
+                - A100_NVLINK_80GB
+      restartPolicy: Never
+  backoffLimit: 2

--- a/manifests/ssh-node.yaml
+++ b/manifests/ssh-node.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: megatron-ssh
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: megatron-ssh
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: megatron-ssh
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: sshd
+          command: [ "/bin/bash", "-c" ]
+          args:
+            - |
+              apt-get -qq update && \
+              DEBIAN_FRONTEND=noninteractive \
+                apt-get -qq install --no-install-recommends -y \
+                ssh ca-certificates tini bash \
+                libncurses5 curl wget sudo htop git rsync locales \
+                tmux unzip nano vim apt-utils iputils-ping && \
+              apt-get clean && \
+              locale-gen en_US.UTF-8 && \
+              rm /etc/ssh/ssh_host_* && \
+              \
+              install -d --mode=0755 --owner=0 --group=0 /var/run/sshd && \
+              install -d --mode=0700 --owner=0 --group=0 /root/.ssh && \
+              install --mode=600 --owner=0 --group=0 /dev/null /etc/ssh/sshd_config.d/10-key-auth.conf && \
+              echo "PasswordAuthentication no" >> /etc/ssh/sshd_config.d/10-key-auth.conf && \
+              echo "PermitRootLogin without-password" >> /etc/ssh/sshd_config.d/10-key-auth.conf && \
+              sed -i -E -e \
+                's:session(\s*)required(\s*)pam_loginuid\.so:session\1optional\2pam_loginuid.so:g' \
+                /etc/pam.d/sshd && \
+              echo 'Set disable_coredump false' >> /etc/sudo.conf && \
+              \
+              ln -s /etc/ssh/host_config/ssh_host_ed25519_key /etc/ssh/ssh_host_ed25519_key
+              install --mode=600 --owner=0 --group=0 /etc/ssh/host_config/authorized_keys /root/.ssh/authorized_keys && \
+              ssh-keygen -f /etc/ssh/ssh_host_ed25519_key -y > /etc/ssh/ssh_host_ed25519_key.pub && \
+              \
+              exec /usr/bin/tini -- service ssh start -D
+          tty: true
+          image: nvcr.io/nvidia/pytorch:23.06-py3
+          ports:
+            - name: sshd
+              containerPort: 22
+              protocol: TCP
+          volumeMounts:
+            - name: megatron-dev
+              mountPath: /mnt/pvc
+            - name: ssh-host-config
+              mountPath: "/etc/ssh/host_config"
+              readOnly: true
+            - name: dshm
+              mountPath: /dev/shm
+            - name: run-lock
+              mountPath: /run/lock
+
+          resources:
+            requests:
+              cpu: 32
+              memory: 512Gi
+            limits:
+              cpu: 32
+              memory: 512Gi
+              nvidia.com/gpu: 8
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: gpu.nvidia.com/class
+                    operator: In
+                    values:
+                      - A40
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - LAS1
+
+      volumes:
+        - name: ssh-host-config
+          secret:
+            secretName: ssh-host-config
+            defaultMode: 0600
+        - name: run-lock
+          emptyDir:
+            medium: Memory
+        - name: megatron-dev
+          persistentVolumeClaim:
+            claimName: megatron-dev
+        - name: dshm
+          emptyDir:
+            medium: Memory
+      restartPolicy: Always

--- a/pretrain_single_node.sh
+++ b/pretrain_single_node.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Runs the "345M" parameter model
+
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+
+GPUS_PER_NODE=8
+# Change for multinode config
+MASTER_ADDR=localhost
+MASTER_PORT=6000
+NNODES=1
+NODE_RANK=0
+WORLD_SIZE=$(($GPUS_PER_NODE*$NNODES))
+
+CHECKPOINT_PATH=/mnt/pvc/checkpoints
+VOCAB_FILE=/mnt/pvc/megatron-dev-dataset/gpt2-vocab.json
+MERGE_FILE=/mnt/pvc/megatron-dev-dataset/gpt2-merges.txt
+DATA_PATH=/mnt/pvc/megatron-dev-dataset/gpt2c4_text_document
+
+DISTRIBUTED_ARGS="
+    --nproc_per_node $GPUS_PER_NODE \
+    --nnodes $NNODES \
+    --node_rank $NODE_RANK \
+    --master_addr $MASTER_ADDR \
+    --master_port $MASTER_PORT
+"
+
+GPT_ARGS="
+    --tensor-model-parallel-size 2 \
+    --pipeline-model-parallel-size 2 \
+    --sequence-parallel \
+    --num-layers 24 \
+    --hidden-size 1024 \
+    --num-attention-heads 16 \
+    --seq-length 1024 \
+    --max-position-embeddings 1024 \
+    --micro-batch-size 4 \
+    --global-batch-size 16 \
+    --lr 0.00015 \
+    --train-iters 500000 \
+    --lr-decay-iters 320000 \
+    --lr-decay-style cosine \
+    --min-lr 1.0e-5 \
+    --weight-decay 1e-2 \
+    --lr-warmup-fraction .01 \
+    --clip-grad 1.0 \
+    --fp16
+"
+
+DATA_ARGS="
+    --data-path $DATA_PATH \
+    --vocab-file $VOCAB_FILE \
+    --merge-file $MERGE_FILE \
+    --data-impl mmap \
+    --split 949,50,1
+"
+
+OUTPUT_ARGS="
+    --log-interval 100 \
+    --save-interval 10000 \
+    --eval-interval 1000 \
+    --eval-iters 10
+"
+
+torchrun $DISTRIBUTED_ARGS pretrain_gpt.py \
+    $GPT_ARGS \
+    $DATA_ARGS \
+    $OUTPUT_ARGS \
+    --distributed-backend nccl \
+    --save $CHECKPOINT_PATH \
+    --load $CHECKPOINT_PATH


### PR DESCRIPTION
The goal of this PR is to allow much less painful development for Megatron, these changes so far manage to:

- Setup a PVC for megatron, this will house an example dataset and the code being worked on.
- Downloads an example dataset [from here](https://huggingface.co/datasets/hakurei/megatron-dev-dataset) and clones the CoreWeave megatron fork.
- Sets up a single-node trainer for preliminary testing by pretraining a 345M GPT model from scratch against the small example dataset.

A goal right now is to actually setup multi-node trainer to investigate optimizing the checkpoint saving and loading code. Additionally, there is also a single-node pretraining shell script in this PR which saves checkpoints in the created PVC under the folder ``checkpoints``.