### PR TITLE
feat(manifests): Add Kubernetes manifests for an SSH development node

### DIFF
--- a/manifests/02-ssh-service.yaml
+++ b/manifests/02-ssh-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: megatron-ssh
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+    - name: sshd
+      port: 22
+      protocol: TCP
+      targetPort: sshd
+  selector:
+    app.kubernetes.io/name: megatron-ssh

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,0 +1,95 @@
+# CoreWeave-Megatron Development Manifests
+
+This directory contains Kubernetes manifests and commands to set up a remote development environment
+for running Megatron.
+
+Using these, you may:
+
+- Set up a Persistent Volume Claim (PVC) to hold testing datasets and modified versions of Megatron code
+  for Kubernetes Pods to access
+- Download testing datasets and clone repositories to the PVC
+- Launch one-off training runs as Kubernetes *Jobs*
+- Allocate a Kubernetes Pod as an SSH host to rapidly test changes with many single-node runs,
+  or to debug interactively
+    - This also allows easier access to deploy code updates onto the PVC.
+
+## Preliminary Setup
+
+> 🛈 These commands need only ever be run once, as prerequisites for launching later Pods.
+
+### Persistent Volume Claim for Testing Data
+
+First, set up a PVC (`megatron-pvc`) to house custom data for testing Megatron:
+
+```bash
+kubectl apply -f 00-megatron-pvc.yaml
+```
+
+### Download Testing Data
+
+Then, start a Job to download an example dataset
+[from here](https://huggingface.co/datasets/hakurei/megatron-dev-dataset)
+and clone the CoreWeave Megatron fork to the PVC:
+
+```bash
+kubectl apply -f 01-dataset-download.yaml
+```
+
+### Usage
+
+From here, continue to either the [One-Off Training Runs](#one-off-training-runs) or [SSH Pod](#ssh-pod) sections,
+as appropriate.
+
+## One-Off Training Runs
+
+These manifests allow you to launch one-off training runs as Kubernetes *Jobs*.
+
+> 🛈 Follow the instructions under [Preliminary Setup](#preliminary-setup) before continuing with this section.
+
+### On a Single Node
+
+Pre-train a 345M GPT model from scratch against the example dataset downloaded in the
+[Download Testing Data](#download-testing-data) section by applying the following Kubernetes Job manifest:
+
+```bash
+kubectl apply -f single-node-trainer.yaml
+```
+
+Checkpoints are recorded in the PVC under the `checkpoints/` directory.
+
+### On Multiple Nodes
+
+> ⚠ Work in Progress
+
+## SSH Pod
+
+This section deploys an SSH server container that may be used for single-node interactive testing and development.
+
+Notes:
+
+- Only the `megatron-pvc` mount holds persistent data by default
+- The entire configuration of the SSH server happens on pod startup in the deployment definition
+    - This means starting up the server takes a minute longer, but does not require a base image customized for SSH use
+
+> 🛈 Follow the instructions under [Preliminary Setup](#preliminary-setup) before continuing with this section.
+
+To deploy the container, execute the following commands from this directory:
+
+1. `kubectl apply -f 02-ssh-service.yaml`
+    - Creates a Kubernetes Service to provide the IP address for connecting to the SSH Pod
+2. `bash init-ssh-host-secret.sh`
+    - Creates a Kubernetes Secret to deploy `ssh_host_ed25519_key` and `authorized_keys` files
+3. `bash replace-ssh-authorized-keys.sh ~/.ssh/id_rsa.pub`
+    - **Use a public key or pre-existing `authorized_keys` file of your choice here** in place of `~/.ssh/id_rsa.pub`
+    - Configures the `root` user's `authorized_keys` file on Pod startup
+    - Restart the Pod to apply changes to this setting
+4. `kubectl apply -f ssh-node.yaml`
+    - Launches the SSH Pod as a Kubernetes Deployment
+5. `kubectl get service/megatron-ssh`
+    - Shows the IP address for the SSH server
+    - Use the value shown in the "`EXTERNAL-IP`" field to connect
+6. `ssh root@X.X.X.X`
+    - Connects to the node
+    - Use the `EXTERNAL-IP` from the previous step in place of `X.X.X.X`
+
+To shut down the SSH server, run `kubectl delete deployment/megatron-ssh`.

--- a/manifests/init-ssh-host-secret.sh
+++ b/manifests/init-ssh-host-secret.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+make-secret() {
+  kubectl create secret generic ssh-host-config-1 --from-file=$1;
+}
+
+mkfifo ./ssh_host_ed25519_key_1 && \
+  { { make-secret ./ssh_host_ed25519_key_1; rm ./ssh_host_ed25519_key_1; } & } && \
+  { echo y | ssh-keygen -t ed25519 -N '' -q -f ./ssh_host_ed25519_key_1 > /dev/null; } || \
+  rm ./ssh_host_ed25519_key_1;

--- a/manifests/replace-ssh-authorized-keys.sh
+++ b/manifests/replace-ssh-authorized-keys.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+kubectl get secret ssh-host-config -o json \
+  | jq --arg authorized_keys "$(base64 -w0 < $1)" \
+    '.data["authorized_keys"]=$authorized_keys' \
+  | kubectl apply -f -;

--- a/manifests/ssh-node.yaml
+++ b/manifests/ssh-node.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: megatron-ssh
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: megatron-ssh
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: megatron-ssh
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: sshd
+          command: [ "/bin/bash", "-c" ]
+          args:
+            - |
+              apt-get -qq update && \
+              DEBIAN_FRONTEND=noninteractive \
+                apt-get -qq install --no-install-recommends -y \
+                ssh ca-certificates tini bash \
+                libncurses5 curl wget sudo htop git rsync locales \
+                tmux unzip nano vim apt-utils iputils-ping && \
+              apt-get clean && \
+              locale-gen en_US.UTF-8 && \
+              rm /etc/ssh/ssh_host_* && \
+              \
+              install -d --mode=0755 --owner=0 --group=0 /var/run/sshd && \
+              install -d --mode=0700 --owner=0 --group=0 /root/.ssh && \
+              install --mode=600 --owner=0 --group=0 /dev/null /etc/ssh/sshd_config.d/10-key-auth.conf && \
+              echo "PasswordAuthentication no" >> /etc/ssh/sshd_config.d/10-key-auth.conf && \
+              echo "PermitRootLogin without-password" >> /etc/ssh/sshd_config.d/10-key-auth.conf && \
+              sed -i -E -e \
+                's:session(\s*)required(\s*)pam_loginuid\.so:session\1optional\2pam_loginuid.so:g' \
+                /etc/pam.d/sshd && \
+              echo 'Set disable_coredump false' >> /etc/sudo.conf && \
+              \
+              ln -s /etc/ssh/host_config/ssh_host_ed25519_key /etc/ssh/ssh_host_ed25519_key
+              install --mode=600 --owner=0 --group=0 /etc/ssh/host_config/authorized_keys /root/.ssh/authorized_keys && \
+              ssh-keygen -f /etc/ssh/ssh_host_ed25519_key -y > /etc/ssh/ssh_host_ed25519_key.pub && \
+              \
+              exec /usr/bin/tini -- service ssh start -D
+          tty: true
+          image: nvcr.io/nvidia/pytorch:23.06-py3
+          ports:
+            - name: sshd
+              containerPort: 22
+              protocol: TCP
+          volumeMounts:
+            - name: megatron-dev
+              mountPath: /mnt/pvc
+            - name: ssh-host-config
+              mountPath: "/etc/ssh/host_config"
+              readOnly: true
+            - name: dshm
+              mountPath: /dev/shm
+            - name: run-lock
+              mountPath: /run/lock
+
+          resources:
+            requests:
+              cpu: 32
+              memory: 512Gi
+            limits:
+              cpu: 32
+              memory: 512Gi
+              nvidia.com/gpu: 8
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: gpu.nvidia.com/class
+                    operator: In
+                    values:
+                      - A40
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - LAS1
+
+      volumes:
+        - name: ssh-host-config
+          secret:
+            secretName: ssh-host-config
+            defaultMode: 0600
+        - name: run-lock
+          emptyDir:
+            medium: Memory
+        - name: megatron-dev
+          persistentVolumeClaim:
+            claimName: megatron-dev
+        - name: dshm
+          emptyDir:
+            medium: Memory
+      restartPolicy: Always


### PR DESCRIPTION
This change adds an SSH server container to `manifests` (see #1) that may be used for single-node interactive testing and development.

- It is based on the [`cuda-ssh` example from `coreweave/kubernetes-cloud`](https://github.com/coreweave/kubernetes-cloud/tree/15e08673c1cb8828551fb9bed1e3f5dbb85cb870/cuda-ssh), but does not feature whole-disk persistence.
  - Only the `megatron-pvc` mount holds persistent data by default.
- The entire configuration of the SSH server, [based on the `cuda-ssh` containers from `coreweave/ml-containers`](https://github.com/coreweave/ml-containers/blob/232785d01666d97dd263769572180c51fe10bcc7/cuda-ssh/Dockerfile), happens on pod startup in the deployment definition.
  - This means starting up the server takes a minute longer, but it does not require a customized base image with e.g. OpenSSH Server pre-installed.

To deploy the container, execute the following:
```bash
cd manifests

kubectl apply -f 00-megatron-pvc.yaml
kubectl apply -f 01-dataset-download.yaml
kubectl apply -f 02-ssh-service.yaml

# Create a Kubernetes secret to deploy `ssh_host_ed25519_key` and `authorized_keys` files
bash init-ssh-host-secret.sh

# Use a public key or pre-existing `authorized_keys` file of your choice here:
bash replace-ssh-authorized-keys.sh ~/.ssh/id_rsa.pub

# Start the container
kubectl apply -f ssh-node.yaml

# Get the IP address
kubectl get service/megatron-ssh

# Connect
ssh root@X.X.X.X
```