### PR TITLE
Multi-Node Training with Kubeflow's PyTorchJobs

### DIFF
--- a/manifests/01-dataset-download.yaml
+++ b/manifests/01-dataset-download.yaml
@@ -14,7 +14,7 @@ spec:
         - |
           cd /mnt/pvc
           git clone https://huggingface.co/datasets/hakurei/megatron-dev-dataset
-          git clone -b amercurio/manifests https://github.com/coreweave/coreweave-megatron
+          git clone -b coreweave-main https://github.com/coreweave/coreweave-megatron
         volumeMounts:
           - name: megatron-dev
             mountPath: /mnt/pvc

--- a/manifests/multi-node-trainer.yaml
+++ b/manifests/multi-node-trainer.yaml
@@ -18,7 +18,7 @@ spec:
             command:
             - "/bin/bash"
             - "-c"
-            - "cd /mnt/pvc/coreweave-megatron && ./pretrain_multi_node.sh"
+            - "cd /mnt/pvc/coreweave-megatron && rm -rf ../checkpoints && ./pretrain_multi_node.sh"
             tty: true
             env:
             - name: GPUS_PER_NODE
@@ -40,11 +40,11 @@ spec:
             resources:
               requests:
                 cpu: 32
-                memory: 512Gi
+                memory: 128Gi
                 nvidia.com/gpu: 1
               limits:
                 cpu: 32
-                memory: 512Gi 
+                memory: 128Gi 
                 nvidia.com/gpu: 1
           volumes:
             - name: megatron-dev
@@ -68,7 +68,7 @@ spec:
                     - A40
           restartPolicy: Never
     Worker:
-      replicas: 16
+      replicas: 3
       template:
         metadata:
           annotations:
@@ -81,7 +81,7 @@ spec:
             command:
             - "/bin/bash"
             - "-c"
-            - "cd /mnt/pvc/coreweave-megatron && ./pretrain_multi_node.sh"
+            - "cd /mnt/pvc/coreweave-megatron && rm -rf ../checkpoints && ./pretrain_multi_node.sh"
             tty: true
             env:
             - name: GPUS_PER_NODE
@@ -103,11 +103,11 @@ spec:
             resources:
               requests:
                 cpu: 32
-                memory: 512Gi
+                memory: 128Gi
                 nvidia.com/gpu: 1
               limits:
                 cpu: 32
-                memory: 512Gi 
+                memory: 128Gi 
                 nvidia.com/gpu: 1
           volumes:
             - name: megatron-dev

--- a/manifests/multi-node-trainer.yaml
+++ b/manifests/multi-node-trainer.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: megatron-train-job-single-node
+  name: megatron-train-job-0
 spec:
   template:
     spec:
@@ -24,12 +24,12 @@ spec:
         resources:
           requests:
             cpu: 32
-            memory: 256Gi
-            nvidia.com/gpu: 2
+            memory: 512Gi
+            nvidia.com/gpu: 8
           limits:
             cpu: 32
-            memory: 256Gi 
-            nvidia.com/gpu: 2
+            memory: 512Gi 
+            nvidia.com/gpu: 8
       volumes:
         - name: megatron-dev
           persistentVolumeClaim:
@@ -56,7 +56,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: megatron-train-job-single-node
+  name: megatron-train-job-1
 spec:
   template:
     spec:
@@ -79,12 +79,12 @@ spec:
         resources:
           requests:
             cpu: 32
-            memory: 256Gi
-            nvidia.com/gpu: 2
+            memory: 512Gi
+            nvidia.com/gpu: 8
           limits:
             cpu: 32
-            memory: 256Gi 
-            nvidia.com/gpu: 2
+            memory: 512Gi 
+            nvidia.com/gpu: 8
       volumes:
         - name: megatron-dev
           persistentVolumeClaim:

--- a/manifests/multi-node-trainer.yaml
+++ b/manifests/multi-node-trainer.yaml
@@ -16,11 +16,20 @@ spec:
             image: nvcr.io/nvidia/pytorch:23.06-py3
             imagePullPolicy: IfNotPresent
             command:
-            - "/mnt/pvc/coreweave-megatron/pretrain_multi_node.sh"
+            - "/bin/bash"
+            - "-c"
+            - "cd /mnt/pvc/coreweave-megatron && ./pretrain_multi_node.sh"
             tty: true
             env:
             - name: GPUS_PER_NODE
               value: "1"
+            # Model Config, you can find values here: https://arxiv.org/pdf/2005.14165.pdf
+            - name: N_LAYERS
+              value: "12"
+            - name: D_MODEL
+              value: "768"
+            - name: N_HEADS
+              value: "12"
             securityContext:
               runAsUser: 0
             volumeMounts:
@@ -59,7 +68,7 @@ spec:
                     - A40
           restartPolicy: Never
     Worker:
-      replicas: 1
+      replicas: 16
       template:
         metadata:
           annotations:
@@ -70,11 +79,20 @@ spec:
             image: nvcr.io/nvidia/pytorch:23.06-py3
             imagePullPolicy: IfNotPresent
             command:
-            - "/mnt/pvc/coreweave-megatron/pretrain_multi_node.sh"
+            - "/bin/bash"
+            - "-c"
+            - "cd /mnt/pvc/coreweave-megatron && ./pretrain_multi_node.sh"
             tty: true
             env:
             - name: GPUS_PER_NODE
               value: "1"
+            # Model Config, you can find values here: https://arxiv.org/pdf/2005.14165.pdf
+            - name: N_LAYERS
+              value: "12"
+            - name: D_MODEL
+              value: "768"
+            - name: N_HEADS
+              value: "12"
             securityContext:
               runAsUser: 0
             volumeMounts:

--- a/manifests/multi-node-trainer.yaml
+++ b/manifests/multi-node-trainer.yaml
@@ -1,0 +1,109 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: megatron-train-job-single-node
+spec:
+  template:
+    spec:
+      containers:
+      - name: megatron-train
+        image: nvcr.io/nvidia/pytorch:23.06-py3
+        imagePullPolicy: IfNotPresent
+        command: ["sleep", "infinity"]
+        tty: true
+        env:
+        - name: NODE_RANK
+          value: "0"
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+          - name: megatron-dev
+            mountPath: /mnt/pvc
+          - name: dshm
+            mountPath: /dev/shm
+        resources:
+          requests:
+            cpu: 32
+            memory: 256Gi
+            nvidia.com/gpu: 2
+          limits:
+            cpu: 32
+            memory: 256Gi 
+            nvidia.com/gpu: 2
+      volumes:
+        - name: megatron-dev
+          persistentVolumeClaim:
+            claimName: megatron-dev
+        - emptyDir:
+            medium: Memory
+          name: dshm
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/region
+                operator: In
+                values: 
+                - LAS1
+              - key: gpu.nvidia.com/class
+                operator: In
+                values:
+                - A40
+      restartPolicy: Never
+  backoffLimit: 2
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: megatron-train-job-single-node
+spec:
+  template:
+    spec:
+      containers:
+      - name: megatron-train
+        image: nvcr.io/nvidia/pytorch:23.06-py3
+        imagePullPolicy: IfNotPresent
+        command: ["sleep", "infinity"]
+        tty: true
+        env:
+        - name: NODE_RANK
+          value: "1"
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+          - name: megatron-dev
+            mountPath: /mnt/pvc
+          - name: dshm
+            mountPath: /dev/shm
+        resources:
+          requests:
+            cpu: 32
+            memory: 256Gi
+            nvidia.com/gpu: 2
+          limits:
+            cpu: 32
+            memory: 256Gi 
+            nvidia.com/gpu: 2
+      volumes:
+        - name: megatron-dev
+          persistentVolumeClaim:
+            claimName: megatron-dev
+        - emptyDir:
+            medium: Memory
+          name: dshm
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/region
+                operator: In
+                values: 
+                - LAS1
+              - key: gpu.nvidia.com/class
+                operator: In
+                values:
+                - A40
+      restartPolicy: Never
+  backoffLimit: 2

--- a/manifests/multi-node-trainer.yaml
+++ b/manifests/multi-node-trainer.yaml
@@ -1,109 +1,114 @@
-apiVersion: batch/v1
-kind: Job
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
 metadata:
-  name: megatron-train-job-0
+  name: megatron-pytorchjob
 spec:
-  template:
-    spec:
-      containers:
-      - name: megatron-train
-        image: nvcr.io/nvidia/pytorch:23.06-py3
-        imagePullPolicy: IfNotPresent
-        command: ["sleep", "infinity"]
-        tty: true
-        env:
-        - name: NODE_RANK
-          value: "0"
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-          - name: megatron-dev
-            mountPath: /mnt/pvc
-          - name: dshm
-            mountPath: /dev/shm
-        resources:
-          requests:
-            cpu: 32
-            memory: 512Gi
-            nvidia.com/gpu: 8
-          limits:
-            cpu: 32
-            memory: 512Gi 
-            nvidia.com/gpu: 8
-      volumes:
-        - name: megatron-dev
-          persistentVolumeClaim:
-            claimName: megatron-dev
-        - emptyDir:
-            medium: Memory
-          name: dshm
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: topology.kubernetes.io/region
-                operator: In
-                values: 
-                - LAS1
-              - key: gpu.nvidia.com/class
-                operator: In
-                values:
-                - A40
-      restartPolicy: Never
-  backoffLimit: 2
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: megatron-train-job-1
-spec:
-  template:
-    spec:
-      containers:
-      - name: megatron-train
-        image: nvcr.io/nvidia/pytorch:23.06-py3
-        imagePullPolicy: IfNotPresent
-        command: ["sleep", "infinity"]
-        tty: true
-        env:
-        - name: NODE_RANK
-          value: "1"
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-          - name: megatron-dev
-            mountPath: /mnt/pvc
-          - name: dshm
-            mountPath: /dev/shm
-        resources:
-          requests:
-            cpu: 32
-            memory: 512Gi
-            nvidia.com/gpu: 8
-          limits:
-            cpu: 32
-            memory: 512Gi 
-            nvidia.com/gpu: 8
-      volumes:
-        - name: megatron-dev
-          persistentVolumeClaim:
-            claimName: megatron-dev
-        - emptyDir:
-            medium: Memory
-          name: dshm
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: topology.kubernetes.io/region
-                operator: In
-                values: 
-                - LAS1
-              - key: gpu.nvidia.com/class
-                operator: In
-                values:
-                - A40
-      restartPolicy: Never
-  backoffLimit: 2
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
+        spec:
+          containers:
+          - name: megatron-train
+            image: nvcr.io/nvidia/pytorch:23.06-py3
+            imagePullPolicy: IfNotPresent
+            command:
+            - "/mnt/pvc/coreweave-megatron/pretrain_multi_node.sh"
+            tty: true
+            env:
+            - name: GPUS_PER_NODE
+              value: "2"
+            securityContext:
+              runAsUser: 0
+            volumeMounts:
+              - name: megatron-dev
+                mountPath: /mnt/pvc
+              - name: dshm
+                mountPath: /dev/shm
+            resources:
+              requests:
+                cpu: 32
+                memory: 512Gi
+                nvidia.com/gpu: 1
+              limits:
+                cpu: 32
+                memory: 512Gi 
+                nvidia.com/gpu: 1
+          volumes:
+            - name: megatron-dev
+              persistentVolumeClaim:
+                claimName: megatron-dev
+            - emptyDir:
+                medium: Memory
+              name: dshm
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values: 
+                    - LAS1
+                  - key: gpu.nvidia.com/class
+                    operator: In
+                    values:
+                    - A40
+          restartPolicy: Never
+    Worker:
+      replicas: 2
+      template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
+        spec:
+          containers:
+          - name: megatron-train
+            image: nvcr.io/nvidia/pytorch:23.06-py3
+            imagePullPolicy: IfNotPresent
+            command:
+            - "/mnt/pvc/coreweave-megatron/pretrain_multi_node.sh"
+            tty: true
+            env:
+            - name: GPUS_PER_NODE
+              value: "2"
+            securityContext:
+              runAsUser: 0
+            volumeMounts:
+              - name: megatron-dev
+                mountPath: /mnt/pvc
+              - name: dshm
+                mountPath: /dev/shm
+            resources:
+              requests:
+                cpu: 32
+                memory: 512Gi
+                nvidia.com/gpu: 1
+              limits:
+                cpu: 32
+                memory: 512Gi 
+                nvidia.com/gpu: 1
+          volumes:
+            - name: megatron-dev
+              persistentVolumeClaim:
+                claimName: megatron-dev
+            - emptyDir:
+                medium: Memory
+              name: dshm
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values: 
+                    - LAS1
+                  - key: gpu.nvidia.com/class
+                    operator: In
+                    values:
+                    - A40
+          restartPolicy: Never

--- a/manifests/multi-node-trainer.yaml
+++ b/manifests/multi-node-trainer.yaml
@@ -12,7 +12,7 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           containers:
-          - name: megatron-train
+          - name: pytorch
             image: nvcr.io/nvidia/pytorch:23.06-py3
             imagePullPolicy: IfNotPresent
             command:
@@ -20,7 +20,7 @@ spec:
             tty: true
             env:
             - name: GPUS_PER_NODE
-              value: "2"
+              value: "1"
             securityContext:
               runAsUser: 0
             volumeMounts:
@@ -59,14 +59,14 @@ spec:
                     - A40
           restartPolicy: Never
     Worker:
-      replicas: 2
+      replicas: 1
       template:
         metadata:
           annotations:
             sidecar.istio.io/inject: "false"
         spec:
           containers:
-          - name: megatron-train
+          - name: pytorch
             image: nvcr.io/nvidia/pytorch:23.06-py3
             imagePullPolicy: IfNotPresent
             command:
@@ -74,7 +74,7 @@ spec:
             tty: true
             env:
             - name: GPUS_PER_NODE
-              value: "2"
+              value: "1"
             securityContext:
               runAsUser: 0
             volumeMounts:

--- a/manifests/multi-node-trainer.yaml
+++ b/manifests/multi-node-trainer.yaml
@@ -30,6 +30,10 @@ spec:
               value: "768"
             - name: N_HEADS
               value: "12"
+            - name: M_BS
+              value: "1"
+            - name: G_BS
+              value: "16"
             securityContext:
               runAsUser: 0
             volumeMounts:
@@ -93,6 +97,10 @@ spec:
               value: "768"
             - name: N_HEADS
               value: "12"
+            - name: M_BS
+              value: "1"
+            - name: G_BS
+              value: "16"
             securityContext:
               runAsUser: 0
             volumeMounts:

--- a/pretrain_multi_node.sh
+++ b/pretrain_multi_node.sh
@@ -55,6 +55,13 @@ DATA_ARGS="
     --split 949,50,1
 "
 
+OUTPUT_ARGS="
+    --log-interval 100 \
+    --save-interval 100 \
+    --eval-interval 1000 \
+    --eval-iters 10
+"
+
 LOG_ARGS="
     --timing-log-level=1 \
     --timing-log-option=all

--- a/pretrain_multi_node.sh
+++ b/pretrain_multi_node.sh
@@ -12,7 +12,7 @@ DATA_PATH=/mnt/pvc/megatron-dev-dataset/gpt2c4_text_document
 DISTRIBUTED_ARGS="
     --nproc_per_node $GPUS_PER_NODE \
     --nnodes $(($WORLD_SIZE*$GPUS_PER_NODE)) \
-    --node_rank $NODE_RANK \
+    --node_rank $RANK \
     --master_addr $MASTER_ADDR \
     --master_port $MASTER_PORT
 "

--- a/pretrain_multi_node.sh
+++ b/pretrain_multi_node.sh
@@ -18,16 +18,13 @@ DISTRIBUTED_ARGS="
 "
 
 GPT_ARGS="
-    --tensor-model-parallel-size 2 \
-    --pipeline-model-parallel-size 2 \
-    --sequence-parallel \
-    --num-layers 16 \
-    --hidden-size 1024 \
-    --num-attention-heads 16 \
+    --num-layers $N_LAYERS \
+    --hidden-size $D_MODEL \
+    --num-attention-heads $N_HEADS \
     --seq-length 1024 \
     --max-position-embeddings 1024 \
-    --micro-batch-size 4 \
-    --global-batch-size 16 \
+    --micro-batch-size 8 \
+    --global-batch-size 64 \
     --lr 0.00015 \
     --train-iters 500000 \
     --lr-decay-iters 320000 \

--- a/pretrain_multi_node.sh
+++ b/pretrain_multi_node.sh
@@ -18,9 +18,6 @@ DISTRIBUTED_ARGS="
 "
 
 GPT_ARGS="
-    --tensor-model-parallel-size 2 \
-    --pipeline-model-parallel-size 2 \
-    --sequence-parallel \
     --num-layers $N_LAYERS \
     --hidden-size $D_MODEL \
     --num-attention-heads $N_HEADS \

--- a/pretrain_multi_node.sh
+++ b/pretrain_multi_node.sh
@@ -4,12 +4,12 @@
 
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 
-GPUS_PER_NODE=8
+GPUS_PER_NODE=2
 # Change for multinode config
 MASTER_ADDR=localhost
 MASTER_PORT=6000
-NNODES=1
-NODE_RANK=0
+NNODES=4
+# NODE_RANK=0
 WORLD_SIZE=$(($GPUS_PER_NODE*$NNODES))
 
 CHECKPOINT_PATH=/mnt/pvc/checkpoints
@@ -62,16 +62,11 @@ OUTPUT_ARGS="
     --eval-iters 10
 "
 
-LOG_ARGS="
-    --timing-log-level=1 \
-    --timing-log-option=all
-"
-
 torchrun $DISTRIBUTED_ARGS pretrain_gpt.py \
     $GPT_ARGS \
     $DATA_ARGS \
     $OUTPUT_ARGS \
-    $LOG_ARGS \
     --distributed-backend nccl \
     --save $CHECKPOINT_PATH \
     --load $CHECKPOINT_PATH
+

--- a/pretrain_multi_node.sh
+++ b/pretrain_multi_node.sh
@@ -11,7 +11,7 @@ DATA_PATH=/mnt/pvc/megatron-dev-dataset/gpt2c4_text_document
 
 DISTRIBUTED_ARGS="
     --nproc_per_node $GPUS_PER_NODE \
-    --nnodes $(($WORLD_SIZE*$GPUS_PER_NODE)) \
+    --nnodes $WORLD_SIZE \
     --node_rank $RANK \
     --master_addr $MASTER_ADDR \
     --master_port $MASTER_PORT

--- a/pretrain_multi_node.sh
+++ b/pretrain_multi_node.sh
@@ -23,8 +23,8 @@ GPT_ARGS="
     --num-attention-heads $N_HEADS \
     --seq-length 1024 \
     --max-position-embeddings 1024 \
-    --micro-batch-size 4 \
-    --global-batch-size 16 \
+    --micro-batch-size $M_BS \
+    --global-batch-size $G_BS \
     --lr 0.00015 \
     --train-iters 500000 \
     --lr-decay-iters 320000 \

--- a/pretrain_multi_node.sh
+++ b/pretrain_multi_node.sh
@@ -21,9 +21,9 @@ GPT_ARGS="
     --tensor-model-parallel-size 2 \
     --pipeline-model-parallel-size 2 \
     --sequence-parallel \
-    --num-layers 32 \
-    --hidden-size 4096 \
-    --num-attention-heads 32 \
+    --num-layers 16 \
+    --hidden-size 1024 \
+    --num-attention-heads 16 \
     --seq-length 1024 \
     --max-position-embeddings 1024 \
     --micro-batch-size 4 \

--- a/pretrain_multi_node.sh
+++ b/pretrain_multi_node.sh
@@ -18,13 +18,16 @@ DISTRIBUTED_ARGS="
 "
 
 GPT_ARGS="
-    --num-layers $N_LAYERS \
-    --hidden-size $D_MODEL \
-    --num-attention-heads $N_HEADS \
+    --tensor-model-parallel-size 2 \
+    --pipeline-model-parallel-size 2 \
+    --sequence-parallel \
+    --num-layers 32 \
+    --hidden-size 4096 \
+    --num-attention-heads 32 \
     --seq-length 1024 \
     --max-position-embeddings 1024 \
-    --micro-batch-size 8 \
-    --global-batch-size 64 \
+    --micro-batch-size 4 \
+    --global-batch-size 16 \
     --lr 0.00015 \
     --train-iters 500000 \
     --lr-decay-iters 320000 \

--- a/pretrain_multi_node.sh
+++ b/pretrain_multi_node.sh
@@ -4,11 +4,11 @@
 
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 
-GPUS_PER_NODE=2
+GPUS_PER_NODE=8
 # Change for multinode config
 MASTER_ADDR=localhost
 MASTER_PORT=6000
-NNODES=4
+NNODES=2
 # NODE_RANK=0
 WORLD_SIZE=$(($GPUS_PER_NODE*$NNODES))
 
@@ -55,17 +55,16 @@ DATA_ARGS="
     --split 949,50,1
 "
 
-OUTPUT_ARGS="
-    --log-interval 100 \
-    --save-interval 100 \
-    --eval-interval 1000 \
-    --eval-iters 10
+LOG_ARGS="
+    --timing-log-level=1 \
+    --timing-log-option=all
 "
 
 torchrun $DISTRIBUTED_ARGS pretrain_gpt.py \
     $GPT_ARGS \
     $DATA_ARGS \
     $OUTPUT_ARGS \
+    $LOG_ARGS \
     --distributed-backend nccl \
     --save $CHECKPOINT_PATH \
     --load $CHECKPOINT_PATH

--- a/pretrain_multi_node.sh
+++ b/pretrain_multi_node.sh
@@ -4,14 +4,6 @@
 
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 
-GPUS_PER_NODE=8
-# Change for multinode config
-MASTER_ADDR=localhost
-MASTER_PORT=6000
-NNODES=2
-# NODE_RANK=0
-WORLD_SIZE=$(($GPUS_PER_NODE*$NNODES))
-
 CHECKPOINT_PATH=/mnt/pvc/checkpoints
 VOCAB_FILE=/mnt/pvc/megatron-dev-dataset/gpt2-vocab.json
 MERGE_FILE=/mnt/pvc/megatron-dev-dataset/gpt2-merges.txt
@@ -19,7 +11,7 @@ DATA_PATH=/mnt/pvc/megatron-dev-dataset/gpt2c4_text_document
 
 DISTRIBUTED_ARGS="
     --nproc_per_node $GPUS_PER_NODE \
-    --nnodes $NNODES \
+    --nnodes $(($WORLD_SIZE*$GPUS_PER_NODE)) \
     --node_rank $NODE_RANK \
     --master_addr $MASTER_ADDR \
     --master_port $MASTER_PORT

--- a/pretrain_multi_node.sh
+++ b/pretrain_multi_node.sh
@@ -21,9 +21,9 @@ GPT_ARGS="
     --tensor-model-parallel-size 2 \
     --pipeline-model-parallel-size 2 \
     --sequence-parallel \
-    --num-layers 32 \
-    --hidden-size 4096 \
-    --num-attention-heads 32 \
+    --num-layers $N_LAYERS \
+    --hidden-size $D_MODEL \
+    --num-attention-heads $N_HEADS \
     --seq-length 1024 \
     --max-position-embeddings 1024 \
     --micro-batch-size 4 \

--- a/pretrain_single_node.sh
+++ b/pretrain_single_node.sh
@@ -57,7 +57,7 @@ DATA_ARGS="
 
 OUTPUT_ARGS="
     --log-interval 100 \
-    --save-interval 10000 \
+    --save-interval 100 \
     --eval-interval 1000 \
     --eval-iters 10
 "

--- a/pretrain_single_node.sh
+++ b/pretrain_single_node.sh
@@ -62,10 +62,16 @@ OUTPUT_ARGS="
     --eval-iters 10
 "
 
+LOG_ARGS="
+    --timing-log-level=1 \
+    --timing-log-option=all
+"
+
 torchrun $DISTRIBUTED_ARGS pretrain_gpt.py \
     $GPT_ARGS \
     $DATA_ARGS \
     $OUTPUT_ARGS \
+    $LOG_ARGS \
     --distributed-backend nccl \
     --save $CHECKPOINT_PATH \
     --load $CHECKPOINT_PATH


### PR DESCRIPTION
By using [Kubeflow's PyTorchJobs](https://www.kubeflow.org/docs/components/training/pytorch/) we can deploy multiple pods with 1 GPU each (for ease of scheduling) to test and verify distributed training. Additionally, timing information has also been enabled for the trainer to log a per-rank metric on checkpoint saving and loading. Model configurations can be changed via environment variables in the multi-node training manifest with values referenced here: https://arxiv.org/pdf/2005.14165.pdf.