### PR TITLE
Megatron Tensorizer Integration

### DIFF
--- a/manifests/01-dataset-download.yaml
+++ b/manifests/01-dataset-download.yaml
@@ -14,7 +14,7 @@ spec:
         - |
           cd /mnt/pvc
           git clone https://huggingface.co/datasets/hakurei/megatron-dev-dataset
-          git clone -b coreweave-main https://github.com/coreweave/coreweave-megatron
+          git clone -b amercurio/tensorizer https://github.com/coreweave/coreweave-megatron
         volumeMounts:
           - name: megatron-dev
             mountPath: /mnt/pvc

--- a/manifests/multi-node-trainer.yaml
+++ b/manifests/multi-node-trainer.yaml
@@ -14,52 +14,53 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           containers:
-          - name: pytorch
-            image: nvcr.io/nvidia/pytorch:23.06-py3
-            imagePullPolicy: IfNotPresent
-            command:
-            - "/bin/bash"
-            - "-c"
-            - "cd /mnt/pvc/coreweave-megatron && ./pretrain_multi_node.sh --save-to-pvc" # add --save-to-pvc to save checkpoints to pvc
-            tty: true
-            env:
-            - name: NCCL_DEBUG
-              value: "INFO"
-            - name: GPUS_PER_NODE
-              value: "1"
-            - name: TP_SIZE
-              value: "1"
-            - name: PP_SIZE
-              value: "2"
-            # Model Config, you can find values here: https://arxiv.org/pdf/2005.14165.pdf
-            - name: N_LAYERS
-              value: "32"
-            - name: D_MODEL
-              value: "4096"
-            - name: N_HEADS
-              value: "32"
-            - name: M_BS
-              value: "1"
-            - name: G_BS
-              value: "1"
-            securityContext:
-              runAsUser: 0
-            volumeMounts:
-              - name: megatron-dev
-                mountPath: /mnt/pvc
-              - name: dshm
-                mountPath: /dev/shm
-              - name: checkpoint-dir
-                mountPath: /mnt/checkpoint
-            resources:
-              requests:
-                cpu: 16
-                memory: 128Gi
-                nvidia.com/gpu: 1
-              limits:
-                cpu: 16
-                memory: 128Gi 
-                nvidia.com/gpu: 1
+            - name: pytorch
+              image: nvcr.io/nvidia/pytorch:23.06-py3
+              imagePullPolicy: IfNotPresent
+              command:
+                - "/bin/bash"
+                - "-c"
+                - >
+                  cd /mnt/pvc/coreweave-megatron && 
+                  pip3 install tensorizer==2.7.0 && 
+                  ./pretrain_multi_node.sh
+              tty: true
+              env:
+                - name: GPUS_PER_NODE
+                  value: "1"
+                - name: TP_SIZE
+                  value: "1"
+                - name: PP_SIZE
+                  value: "2"
+                # Model Config, you can find values here: https://arxiv.org/pdf/2005.14165.pdf
+                - name: N_LAYERS
+                  value: "32"
+                - name: D_MODEL
+                  value: "4096"
+                - name: N_HEADS
+                  value: "32"
+                - name: M_BS
+                  value: "1"
+                - name: G_BS
+                  value: "1"
+              securityContext:
+                runAsUser: 0
+              volumeMounts:
+                - name: megatron-dev
+                  mountPath: /mnt/pvc
+                - name: dshm
+                  mountPath: /dev/shm
+              resources:
+                requests:
+                  cpu: 32
+                  memory: 128Gi
+                  ephemeral-storage: 100Gi
+                  nvidia.com/gpu: 1
+                limits:
+                  cpu: 32
+                  memory: 128Gi
+                  ephemeral-storage: 100Gi
+                  nvidia.com/gpu: 1
           volumes:
             - name: megatron-dev
               persistentVolumeClaim:
@@ -67,22 +68,28 @@ spec:
             - emptyDir:
                 medium: Memory
               name: dshm
-            - emptyDir:
-                medium: Memory
-              name: checkpoint-dir
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
-                - matchExpressions:
-                  - key: topology.kubernetes.io/region
-                    operator: In
-                    values: 
-                    - LAS1
-                  - key: gpu.nvidia.com/class
-                    operator: In
-                    values:
-                    - RTX_A6000
+                  - matchExpressions:
+                      - key: topology.kubernetes.io/region
+                        operator: In
+                        values: 
+                          - LAS1
+                      - key: gpu.nvidia.com/class
+                        operator: In
+                        values:
+                          - RTX_A6000
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                      - key: job-name
+                        operator: In
+                        values:
+                          - megatron-pytorchjob
+                  topologyKey: kubernetes.io/hostname
           restartPolicy: Never
     Worker:
       replicas: 1
@@ -94,52 +101,53 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           containers:
-          - name: pytorch
-            image: nvcr.io/nvidia/pytorch:23.06-py3
-            imagePullPolicy: IfNotPresent
-            command:
-            - "/bin/bash"
-            - "-c"
-            - "cd /mnt/pvc/coreweave-megatron && ./pretrain_multi_node.sh --save-to-pvc" # add --save-to-pvc to save checkpoints to pvc
-            tty: true
-            env:
-            - name: NCCL_DEBUG
-              value: "INFO"
-            - name: GPUS_PER_NODE
-              value: "1"
-            - name: TP_SIZE
-              value: "1"
-            - name: PP_SIZE
-              value: "2"
-            # Model Config, you can find values here: https://arxiv.org/pdf/2005.14165.pdf
-            - name: N_LAYERS
-              value: "32"
-            - name: D_MODEL
-              value: "4096"
-            - name: N_HEADS
-              value: "32"
-            - name: M_BS
-              value: "1"
-            - name: G_BS
-              value: "1"
-            securityContext:
-              runAsUser: 0
-            volumeMounts:
-              - name: megatron-dev
-                mountPath: /mnt/pvc
-              - name: dshm
-                mountPath: /dev/shm
-              - name: checkpoint-dir
-                mountPath: /mnt/checkpoint
-            resources:
-              requests:
-                cpu: 16
-                memory: 128Gi
-                nvidia.com/gpu: 1
-              limits:
-                cpu: 16
-                memory: 128Gi 
-                nvidia.com/gpu: 1
+            - name: pytorch
+              image: nvcr.io/nvidia/pytorch:23.06-py3
+              imagePullPolicy: IfNotPresent
+              command:
+                - "/bin/bash"
+                - "-c"
+                - >
+                  cd /mnt/pvc/coreweave-megatron && 
+                  pip3 install tensorizer==2.7.0 && 
+                  ./pretrain_multi_node.sh
+              tty: true
+              env:
+                - name: GPUS_PER_NODE
+                  value: "1"
+                - name: TP_SIZE
+                  value: "1"
+                - name: PP_SIZE
+                  value: "2"
+                # Model Config, you can find values here: https://arxiv.org/pdf/2005.14165.pdf
+                - name: N_LAYERS
+                  value: "32"
+                - name: D_MODEL
+                  value: "4096"
+                - name: N_HEADS
+                  value: "32"
+                - name: M_BS
+                  value: "1"
+                - name: G_BS
+                  value: "1"
+              securityContext:
+                runAsUser: 0
+              volumeMounts:
+                - name: megatron-dev
+                  mountPath: /mnt/pvc
+                - name: dshm
+                  mountPath: /dev/shm
+              resources:
+                requests:
+                  cpu: 32
+                  memory: 128Gi
+                  ephemeral-storage: 100Gi
+                  nvidia.com/gpu: 1
+                limits:
+                  cpu: 32
+                  memory: 128Gi
+                  ephemeral-storage: 100Gi
+                  nvidia.com/gpu: 1
           volumes:
             - name: megatron-dev
               persistentVolumeClaim:
@@ -147,20 +155,26 @@ spec:
             - emptyDir:
                 medium: Memory
               name: dshm
-            - emptyDir:
-                medium: Memory
-              name: checkpoint-dir
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
-                - matchExpressions:
-                  - key: topology.kubernetes.io/region
-                    operator: In
-                    values: 
-                    - LAS1
-                  - key: gpu.nvidia.com/class
-                    operator: In
-                    values:
-                    - RTX_A6000
+                  - matchExpressions:
+                      - key: topology.kubernetes.io/region
+                        operator: In
+                        values: 
+                          - LAS1
+                      - key: gpu.nvidia.com/class
+                        operator: In
+                        values:
+                          - RTX_A6000
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                      - key: job-name
+                        operator: In
+                        values:
+                          - megatron-pytorchjob
+                  topologyKey: kubernetes.io/hostname
           restartPolicy: Never

--- a/manifests/multi-node-trainer.yaml
+++ b/manifests/multi-node-trainer.yaml
@@ -8,6 +8,8 @@ spec:
       replicas: 1
       template:
         metadata:
+          labels:
+            name: megatron-pytorchjob
           annotations:
             sidecar.istio.io/inject: "false"
         spec:
@@ -18,22 +20,28 @@ spec:
             command:
             - "/bin/bash"
             - "-c"
-            - "cd /mnt/pvc/coreweave-megatron && rm -rf ../checkpoints && ./pretrain_multi_node.sh"
+            - "cd /mnt/pvc/coreweave-megatron && ./pretrain_multi_node.sh --save-to-pvc" # add --save-to-pvc to save checkpoints to pvc
             tty: true
             env:
+            - name: NCCL_DEBUG
+              value: "INFO"
             - name: GPUS_PER_NODE
               value: "1"
+            - name: TP_SIZE
+              value: "1"
+            - name: PP_SIZE
+              value: "2"
             # Model Config, you can find values here: https://arxiv.org/pdf/2005.14165.pdf
             - name: N_LAYERS
-              value: "12"
+              value: "32"
             - name: D_MODEL
-              value: "768"
+              value: "4096"
             - name: N_HEADS
-              value: "12"
+              value: "32"
             - name: M_BS
               value: "1"
             - name: G_BS
-              value: "16"
+              value: "1"
             securityContext:
               runAsUser: 0
             volumeMounts:
@@ -41,13 +49,15 @@ spec:
                 mountPath: /mnt/pvc
               - name: dshm
                 mountPath: /dev/shm
+              - name: checkpoint-dir
+                mountPath: /mnt/checkpoint
             resources:
               requests:
-                cpu: 32
+                cpu: 16
                 memory: 128Gi
                 nvidia.com/gpu: 1
               limits:
-                cpu: 32
+                cpu: 16
                 memory: 128Gi 
                 nvidia.com/gpu: 1
           volumes:
@@ -57,6 +67,9 @@ spec:
             - emptyDir:
                 medium: Memory
               name: dshm
+            - emptyDir:
+                medium: Memory
+              name: checkpoint-dir
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -69,12 +82,14 @@ spec:
                   - key: gpu.nvidia.com/class
                     operator: In
                     values:
-                    - A40
+                    - RTX_A6000
           restartPolicy: Never
     Worker:
-      replicas: 3
+      replicas: 1
       template:
         metadata:
+          labels:
+            name: megatron-pytorchjob
           annotations:
             sidecar.istio.io/inject: "false"
         spec:
@@ -85,22 +100,28 @@ spec:
             command:
             - "/bin/bash"
             - "-c"
-            - "cd /mnt/pvc/coreweave-megatron && rm -rf ../checkpoints && ./pretrain_multi_node.sh"
+            - "cd /mnt/pvc/coreweave-megatron && ./pretrain_multi_node.sh --save-to-pvc" # add --save-to-pvc to save checkpoints to pvc
             tty: true
             env:
+            - name: NCCL_DEBUG
+              value: "INFO"
             - name: GPUS_PER_NODE
               value: "1"
+            - name: TP_SIZE
+              value: "1"
+            - name: PP_SIZE
+              value: "2"
             # Model Config, you can find values here: https://arxiv.org/pdf/2005.14165.pdf
             - name: N_LAYERS
-              value: "12"
+              value: "32"
             - name: D_MODEL
-              value: "768"
+              value: "4096"
             - name: N_HEADS
-              value: "12"
+              value: "32"
             - name: M_BS
               value: "1"
             - name: G_BS
-              value: "16"
+              value: "1"
             securityContext:
               runAsUser: 0
             volumeMounts:
@@ -108,13 +129,15 @@ spec:
                 mountPath: /mnt/pvc
               - name: dshm
                 mountPath: /dev/shm
+              - name: checkpoint-dir
+                mountPath: /mnt/checkpoint
             resources:
               requests:
-                cpu: 32
+                cpu: 16
                 memory: 128Gi
                 nvidia.com/gpu: 1
               limits:
-                cpu: 32
+                cpu: 16
                 memory: 128Gi 
                 nvidia.com/gpu: 1
           volumes:
@@ -124,6 +147,9 @@ spec:
             - emptyDir:
                 medium: Memory
               name: dshm
+            - emptyDir:
+                medium: Memory
+              name: checkpoint-dir
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -136,5 +162,5 @@ spec:
                   - key: gpu.nvidia.com/class
                     operator: In
                     values:
-                    - A40
+                    - RTX_A6000
           restartPolicy: Never

--- a/manifests/multi-node-trainer.yaml
+++ b/manifests/multi-node-trainer.yaml
@@ -22,7 +22,7 @@ spec:
                 - "-c"
                 - >
                   cd /mnt/pvc/coreweave-megatron && 
-                  pip3 install tensorizer==2.7.0 && 
+                  pip3 install tensorizer==2.7.1 && 
                   ./pretrain_multi_node.sh
               tty: true
               env:
@@ -109,7 +109,7 @@ spec:
                 - "-c"
                 - >
                   cd /mnt/pvc/coreweave-megatron && 
-                  pip3 install tensorizer==2.7.0 && 
+                  pip3 install tensorizer==2.7.1 && 
                   ./pretrain_multi_node.sh
               tty: true
               env:

--- a/megatron/__init__.py
+++ b/megatron/__init__.py
@@ -2,7 +2,7 @@
 
 import torch
 
-from .global_vars import get_args, get_retro_args
+from .global_vars import get_args, get_retro_args, set_args
 from .global_vars import get_current_global_batch_size
 from .global_vars import get_num_microbatches
 from .global_vars import get_signal_handler

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -854,6 +854,10 @@ def _add_checkpointing_args(parser):
                        help='Output directory to save checkpoints to.')
     group.add_argument('--save-interval', type=int, default=None,
                        help='Number of iterations between checkpoint saves.')
+    group.add_argument('--use-tensorizer', action='store_true',
+                       help='Use Tensorizer for fast model weight serialization '
+                       'and deserialization. Only works for model weights and not '
+                       'optimizer states.')
     group.add_argument('--no-save-optim', action='store_true', default=None,
                        help='Do not save current optimizer.')
     group.add_argument('--no-save-rng', action='store_true', default=None,

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -858,6 +858,9 @@ def _add_checkpointing_args(parser):
                        help='Use Tensorizer for fast model weight serialization '
                        'and deserialization. Only works for model weights and not '
                        'optimizer states.')
+    group.add_argument('--timing-file', type=str, default=None,
+                       help='This option is meant to be used in combination with'
+                       '--use-tensorizer to benchmark model saving and loading.')
     group.add_argument('--no-save-optim', action='store_true', default=None,
                        help='Do not save current optimizer.')
     group.add_argument('--no-save-rng', action='store_true', default=None,

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -78,7 +78,7 @@ def check_checkpoint_args(checkpoint_args):
 def ensure_directory_exists(filename):
     """Build filename's path if it does not already exists."""
     dirname = os.path.dirname(filename)
-    os.makedirs(dirname, exist_ok=True)
+    os.makedirs(dirname, exist_ok = True)
 
 
 def get_checkpoint_name(checkpoints_path, iteration, release=False,
@@ -103,10 +103,10 @@ def get_checkpoint_name(checkpoints_path, iteration, release=False,
     # data parallel rank.
     if not pipeline_parallel:
         common_path = os.path.join(checkpoints_path, directory,
-                                   f'mp_rank_{tensor_rank:02d}')
+                            f'mp_rank_{tensor_rank:02d}')
     else:
         common_path = os.path.join(checkpoints_path, directory,
-                                   f'mp_rank_{tensor_rank:02d}_{pipeline_rank:03d}')
+                        f'mp_rank_{tensor_rank:02d}_{pipeline_rank:03d}')
 
     return os.path.join(common_path, "model_optim_rng.pt")
 
@@ -143,6 +143,7 @@ def find_checkpoint_rank_0(checkpoints_path, iteration, release=False):
 
 
 def get_checkpoint_tracker_filename(checkpoints_path):
+
     """Tracker file rescords the latest chckpoint during
     training to restart from."""
     return os.path.join(checkpoints_path, 'latest_checkpointed_iteration.txt')
@@ -457,7 +458,7 @@ def save_checkpoint_tensorizer(iteration: int, model: torch.nn.Module,
     if torch.distributed.is_initialized():
         torch.distributed.barrier()
 
-    print_rank_0('  successfully saved checkpoint at iteration {:7d} to {}'
+    print_rank_0('  successfully saved checkpoint at iteration {:7d} to {}' \
                  .format(iteration, args.save))
 
     # And update the latest iteration
@@ -675,7 +676,7 @@ def save_checkpoint(iteration: int, model: torch.nn.Module, optimizer: torch.opt
         ensure_directory_exists(checkpoint_name)
         torch.save(state_dict, checkpoint_name)
 
-    print_rank_0('  successfully saved checkpoint at iteration {:7d} to {}'
+    print_rank_0('  successfully saved checkpoint at iteration {:7d} to {}' \
                  .format(iteration, args.save))
 
     # Wait so everyone is done (necessary)
@@ -720,7 +721,7 @@ def _transpose_first_dim(t, num_splits, num_splits_first, model):
         intermediate_shape = \
             (num_attention_heads_per_partition,
              hidden_size_per_attention_head, num_splits) +\
-            input_shape[1:]
+             input_shape[1:]
 
         t = t.view(*intermediate_shape)
         t = t.transpose(1, 2).contiguous()
@@ -728,14 +729,13 @@ def _transpose_first_dim(t, num_splits, num_splits_first, model):
 
     return t
 
-
 def fix_query_key_value_ordering(model, checkpoint_version):
     """Fix up query/key/value matrix ordering if checkpoint
     version is smaller than 2.0
     """
     if checkpoint_version < 2.0:
         if isinstance(model, list):
-            assert len(model) == 1
+            assert len(model)==1
             model = model[0]
         for name, param in model.named_parameters():
             if name.endswith(('.query_key_value.weight', '.query_key_value.bias')):
@@ -757,7 +757,7 @@ def fix_query_key_value_ordering(model, checkpoint_version):
                     sys.exit()
                 param.data.copy_(fixed_param)
         print_rank_0(" succesfully fixed query-key-values ordering for"
-                     " checkpoint version {}".format(checkpoint_version))
+                    " checkpoint version {}".format(checkpoint_version))
 
 
 def _load_base_checkpoint(load_dir, rank0=False):
@@ -851,12 +851,7 @@ def load_args_from_checkpoint(args, load_arg='load'):
 
     # One-off conversion for foundation models
     if hasattr(checkpoint_args, 'disable_bias_linear'):
-        setattr(
-            checkpoint_args,
-            'add_bias_linear',
-            not getattr(
-                checkpoint_args,
-                'disable_bias_linear'))
+        setattr(checkpoint_args, 'add_bias_linear', not getattr(checkpoint_args, 'disable_bias_linear'))
 
     def _set_arg(arg_name, old_arg_name=None, force=False):
         if not force and getattr(args, arg_name, None) is not None:
@@ -900,8 +895,7 @@ def load_args_from_checkpoint(args, load_arg='load'):
     return args, checkpoint_args
 
 
-def load_checkpoint(model: torch.nn.Module, optimizer: torch.optim.Optimizer,
-                    opt_param_scheduler: Any, load_arg: str = 'load', strict: bool = True) -> int:
+def load_checkpoint(model, optimizer, opt_param_scheduler, load_arg='load', strict=True):
     """Load a model checkpoint and return the iteration.
     strict (bool): whether to strictly enforce that the keys in
         :attr:`state_dict` of the checkpoint match the names of
@@ -991,7 +985,7 @@ def load_checkpoint(model: torch.nn.Module, optimizer: torch.optim.Optimizer,
 
             # Load scheduler.
             if opt_param_scheduler is not None:
-                if 'lr_scheduler' in state_dict:  # backward compatbility
+                if 'lr_scheduler' in state_dict: # backward compatbility
                     opt_param_scheduler.load_state_dict(state_dict['lr_scheduler'])
                 else:
                     opt_param_scheduler.load_state_dict(state_dict['opt_param_scheduler'])
@@ -1032,7 +1026,7 @@ def load_checkpoint(model: torch.nn.Module, optimizer: torch.optim.Optimizer,
 
 
 def load_biencoder_checkpoint(model, only_query_model=False,
-                              only_context_model=False, custom_load_path=None):
+        only_context_model=False, custom_load_path=None):
     """
     selectively load retrieval models for indexing/retrieving
     from saved checkpoints

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -328,7 +328,7 @@ def serialize_model_state_dict(state_dict, stem):
 
 def dump_optimizer(opt, checkpoint_name):
     flattened, skeleton = flatten_dict_to_skeleton(opt.state_dict())
-    serializer = TensorSerializer(stream_io.open_stream(f'{checkpoint_name}-opt.tensors', 'wb+', buffer_size=0))
+    serializer = TensorSerializer(f'{checkpoint_name}-opt.tensors')
     serializer.write_state_dict(flattened)
     serializer.close()
     json.dump(skeleton, fp=open(f'{checkpoint_name}-opt.json', 'w'))

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -11,10 +11,8 @@ import json
 import torch
 
 from typing import Union, Dict, List, Tuple, Any, Optional
-from collections import OrderedDict
 from megatron import update_num_microbatches
 from megatron.core import mpu, tensor_parallel
-from megatron.optimizer_param_scheduler import OptimizerParamScheduler
 from .global_vars import get_args
 from .utils import (unwrap_model,
                     print_rank_0)
@@ -387,7 +385,7 @@ def load_main_grads(model: torch.nn.Module, checkpoint_name: str) -> None:
 
 
 def save_checkpoint_tensorizer(iteration: int, model: torch.nn.Module,
-                               optimizer: torch.optim.Optimizer, opt_param_scheduler: OptimizerParamScheduler) -> None:
+                               optimizer: torch.optim.Optimizer, opt_param_scheduler: Any) -> None:
     """Save a model checkpoint."""
     args = get_args()
 
@@ -471,7 +469,7 @@ def save_checkpoint_tensorizer(iteration: int, model: torch.nn.Module,
 
 
 def load_checkpoint_tensorizer(model: torch.nn.Module, optimizer: torch.optim.Optimizer,
-                               opt_param_scheduler: OptimizerParamScheduler, load_arg: str = 'load', strict: bool = True) -> int:
+                               opt_param_scheduler: Any, load_arg: str = 'load', strict: bool = True) -> int:
     """Load a model checkpoint and return the iteration.
     strict (bool): whether to strictly enforce that the keys in
         :attr:`state_dict` of the checkpoint match the names of
@@ -621,7 +619,7 @@ def load_checkpoint_tensorizer(model: torch.nn.Module, optimizer: torch.optim.Op
 
 
 def save_checkpoint(iteration: int, model: torch.nn.Module, optimizer: torch.optim.Optimizer,
-                    opt_param_scheduler: OptimizerParamScheduler) -> None:
+                    opt_param_scheduler: Any) -> None:
     """Save a model checkpoint."""
     args = get_args()
 
@@ -903,7 +901,7 @@ def load_args_from_checkpoint(args, load_arg='load'):
 
 
 def load_checkpoint(model: torch.nn.Module, optimizer: torch.optim.Optimizer,
-                    opt_param_scheduler: OptimizerParamScheduler, load_arg: str = 'load', strict: bool = True) -> int:
+                    opt_param_scheduler: Any, load_arg: str = 'load', strict: bool = True) -> int:
     """Load a model checkpoint and return the iteration.
     strict (bool): whether to strictly enforce that the keys in
         :attr:`state_dict` of the checkpoint match the names of

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -410,14 +410,14 @@ def save_checkpoint_tensorizer(iteration, model, optimizer, opt_param_scheduler)
 
         if len(model) == 1:
             serializer = TensorSerializer(f"{checkpoint_name}.tensors")
-            serializer.write_module(model[0])
+            serializer.write_state_dict(model[0].state_dict_for_save_checkpoint())
             serializer.close()
             dump_main_grads(model[0], f"{checkpoint_name}.tensors")
         else:
             for i in range(len(model)):
                 serializer = TensorSerializer(f"{checkpoint_name}_shard{i}.tensors")
                 mpu.set_virtual_pipeline_model_parallel_rank(i)
-                serializer.write_module(model[i])
+                serializer.write_state_dict(model[i].state_dict_for_save_checkpoint())
                 serializer.close()
                 dump_main_grads(model[i], f"{checkpoint_name}_shard{i}.tensors")
 
@@ -499,14 +499,14 @@ def load_checkpoint_tensorizer(model, optimizer, opt_param_scheduler, load_arg='
     # Model.
     if len(model) == 1:
         deserializer = TensorDeserializer(f"{checkpoint_name}.tensors")
-        deserializer.load_into_module(model[0])
+        model[0].load_state_dict(deserializer)
         deserializer.close()
         load_main_grads(model[0], f"{checkpoint_name}.tensors")
     else:
         for i in range(len(model)):
             deserializer = TensorDeserializer(f"{checkpoint_name}_shard{i}.tensors")
             mpu.set_virtual_pipeline_model_parallel_rank(i)
-            deserializer.load_into_module(model[i])
+            model[i].load_state_dict(deserializer)
             deserializer.close()
             load_main_grads(model[i], f"{checkpoint_name}_shard{i}.tensors")
 

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -336,7 +336,7 @@ def dump_optimizer(opt, checkpoint_name):
 
 def load_optimizer(checkpoint_name):
     opt_state_dict = json.load(fp=open(f'{checkpoint_name}-opt.json', 'r'))
-    deserializer = TensorDeserializer(open(f'{checkpoint_name}-opt.tensors', 'rb'), device=torch.cuda.current_device())
+    deserializer = TensorDeserializer(f'{checkpoint_name}-opt.tensors', device=torch.cuda.current_device(), plaid_mode=True)
     opt_state_dict = unflatten_to_skeleton(deserializer, opt_state_dict)
     convert_parameters_to_tensors(opt_state_dict)
     deserializer.close()
@@ -353,13 +353,13 @@ def map_model_main_grad_to_parameters(model):
 
 def dump_main_grads(model, checkpoint_name):
     main_grads = map_model_main_grad_to_parameters(model)
-    serializer = TensorSerializer(stream_io.open_stream(f'{checkpoint_name}-grad.tensors', 'wb+', buffer_size=0))
+    serializer = TensorSerializer(f'{checkpoint_name}-grad.tensors')
     serializer.write_state_dict(main_grads)
     serializer.close()
 
 
 def load_main_grads(model, checkpoint_name):
-    deserializer = TensorDeserializer(open(f'{checkpoint_name}-grad.tensors', 'rb'))
+    deserializer = TensorDeserializer(f'{checkpoint_name}-grad.tensors', plaid_mode=True, device=torch.cuda.current_device())
     for name, param in model.named_parameters():
         main_grad_value = deserializer[name]
         if isinstance(main_grad_value, torch.nn.Parameter):

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -314,18 +314,6 @@ def convert_parameters_to_tensors(d):
                 convert_parameters_to_tensors(item)
 
 
-def serialize_model_state_dict(state_dict, stem):
-    for k, v in state_dict.items():
-        if isinstance(v, OrderedDict):
-            serializer = TensorSerializer(stream_io.open_stream(f"{stem}.{k}", 'wb+', buffer_size=0))
-            serializer.write_state_dict(v)
-            serializer.close()
-            state_dict[k] = None
-        elif isinstance(v, dict):
-            serialize_model_state_dict(v, stem)
-    return state_dict
-
-
 def dump_optimizer(opt, checkpoint_name):
     flattened, skeleton = flatten_dict_to_skeleton(opt.state_dict())
     serializer = TensorSerializer(f'{checkpoint_name}-opt.tensors')

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -777,7 +777,7 @@ def _load_base_checkpoint(load_dir, rank0=False):
                 tracker_filename))
             print_rank_0('    will not load any checkpoints and will start from '
                          'random')
-        return None, False, None
+        return None, False
 
     # Otherwise, read the tracker file and either set the iteration or
     # mark it as a release checkpoint.
@@ -813,7 +813,7 @@ def _load_base_checkpoint(load_dir, rank0=False):
         print_rank_0(e)
         sys.exit()
 
-    return state_dict, release, checkpoint_name
+    return state_dict, release
 
 
 def load_args_from_checkpoint(args, load_arg='load'):

--- a/megatron/model/module.py
+++ b/megatron/model/module.py
@@ -100,6 +100,10 @@ class MegatronModule(torch.nn.Module):
                 MegatronModule.embedding_warning_printed = True
             return
 
+        # Weights are on the meta device.
+        if args.use_tensorizer:
+            return
+
         # Ensure that first and last stages have the same initial parameter
         # values.
         if mpu.is_rank_in_embedding_group():

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -170,9 +170,9 @@ def pretrain(train_valid_test_dataset_provider,
         iteration = 0
         if args.do_train and args.train_iters > 0:
             iteration = train(forward_step_func,
-                              model, optimizer, opt_param_scheduler,
-                              train_data_iterator, valid_data_iterator,
-                              process_non_loss_data_func)
+                            model, optimizer, opt_param_scheduler,
+                            train_data_iterator, valid_data_iterator,
+                            process_non_loss_data_func)
 
         print_datetime('after training is done')
 
@@ -222,7 +222,7 @@ def update_train_iters(args):
         # Constant phase
         # Note that we throw away any partial last batch.
         iterations += (args.train_samples - consumed_samples) // \
-            args.global_batch_size
+                      args.global_batch_size
         args.train_iters = iterations
 
     print_rank_0('setting training iterations to {}'.format(args.train_iters))
@@ -272,7 +272,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
                 world_size = mpu.get_pipeline_model_parallel_world_size()
                 pre_process = rank == 0 or rank == split_rank
                 post_process = (rank == (split_rank - 1)) or (
-                    rank == (world_size - 1))
+                        rank == (world_size - 1))
                 add_encoder = mpu.is_pipeline_stage_before_split()
                 add_decoder = mpu.is_pipeline_stage_after_split()
             if args.use_tensorizer and args.load:
@@ -325,10 +325,10 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
     if mpu.get_data_parallel_rank() == 0:
         print(' > number of parameters on (tensor, pipeline) '
               'model parallel rank ({}, {}): {}'.format(
-                  mpu.get_tensor_model_parallel_rank(),
-                  mpu.get_pipeline_model_parallel_rank(),
-                  sum([sum([p.nelement() for p in model_module.parameters()])
-                       for model_module in model])), flush=True)
+            mpu.get_tensor_model_parallel_rank(),
+            mpu.get_pipeline_model_parallel_rank(),
+            sum([sum([p.nelement() for p in model_module.parameters()])
+                 for model_module in model])), flush=True)
 
     # GPU allocation.
     if not args.use_tensorizer or args.load is None:
@@ -466,7 +466,7 @@ def setup_model_and_optimizer(model_provider_func,
 
     # get model without FP16 and/or TorchDDP wrappers
     if args.iteration == 0 and len(unwrapped_model) == 1 \
-            and hasattr(unwrapped_model[0], 'init_state_dict_from_bert'):
+        and hasattr(unwrapped_model[0], 'init_state_dict_from_bert'):
         print_rank_0("Initializing ICT from pretrained BERT model")
         unwrapped_model[0].init_state_dict_from_bert()
         if args.fp16:
@@ -538,8 +538,8 @@ def train_step(forward_step_func, data_iterator,
     # Update learning rate.
     if update_successful:
         increment = get_num_microbatches() * \
-            args.micro_batch_size * \
-            args.data_parallel_size
+                    args.micro_batch_size * \
+                    args.data_parallel_size
         opt_param_scheduler.step(increment=increment)
         skipped_iter = 0
     else:
@@ -590,8 +590,8 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
         else:
             value = loss_dict[key].float().sum().item()
             is_nan = value == float('inf') or \
-                value == -float('inf') or \
-                value != value
+                     value == -float('inf') or \
+                     value != value
             got_nan = got_nan or is_nan
     total_loss_dict[nan_iters_key] = total_loss_dict.get(
         nan_iters_key, 0) + int(got_nan)
@@ -629,7 +629,7 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
         get_num_microbatches()
 
     total_iterations = total_loss_dict[advanced_iters_key] + \
-        total_loss_dict[skipped_iters_key]
+                       total_loss_dict[skipped_iters_key]
 
     # Tensorboard values.
     # Timer requires all the ranks to call.
@@ -647,7 +647,7 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
             writer.add_scalar('batch-size vs samples', batch_size,
                               args.consumed_train_samples)
         for key in loss_dict:
-            writer.add_scalar(key, loss_dict[key], iteration)
+            writer.add_scalar(key , loss_dict[key], iteration)
             writer.add_scalar(key + ' vs samples', loss_dict[key],
                               args.consumed_train_samples)
         if args.log_loss_scale_to_tensorboard:
@@ -707,7 +707,7 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
             if key not in [advanced_iters_key, skipped_iters_key,
                            nan_iters_key]:
                 avg = total_loss_dict[key].item() / \
-                    float(max(1, total_loss_dict[advanced_iters_key]))
+                      float(max(1, total_loss_dict[advanced_iters_key]))
                 if avg > 0.0:
                     log_string += ' {}: {:.6E} |'.format(key, avg)
                 total_loss_dict[key] = torch.cuda.FloatTensor([0.0])
@@ -794,8 +794,8 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
                        opt_param_scheduler)
         iteration += 1
         args.consumed_train_samples += mpu.get_data_parallel_world_size() * \
-            args.micro_batch_size * \
-            get_num_microbatches()
+                                       args.micro_batch_size * \
+                                       get_num_microbatches()
 
         # Logging.
         loss_scale = optimizer.get_loss_scale().item()
@@ -863,6 +863,7 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
             print_datetime('exiting program at iteration {}'.format(iteration))
             sys.exit()
 
+
     return iteration
 
 
@@ -915,8 +916,8 @@ def evaluate(forward_step_func,
                             key, torch.cuda.FloatTensor([0.0])) + loss_dict[key]
 
             args.consumed_valid_samples += mpu.get_data_parallel_world_size() \
-                * args.micro_batch_size \
-                * get_num_microbatches()
+                                           * args.micro_batch_size \
+                                           * get_num_microbatches()
         collected_non_loss_data = None
         if process_non_loss_data_func is not None and is_last_rank():
             collected_non_loss_data = forward_backward_func(
@@ -931,7 +932,6 @@ def evaluate(forward_step_func,
         total_loss_dict[key] /= args.eval_iters * get_num_microbatches()
 
     return total_loss_dict, collected_non_loss_data
-
 
 def evaluate_and_print_results(prefix, forward_step_func,
                                data_iterator, model,
@@ -991,7 +991,7 @@ def build_train_valid_test_datasets(build_train_valid_test_datasets_provider):
     else:
         train_samples = args.train_iters * args.global_batch_size
     eval_iters = (args.train_iters // args.eval_interval + 1) * \
-        args.eval_iters
+                 args.eval_iters
     test_iters = args.eval_iters
     train_val_test_num_samples = [train_samples,
                                   eval_iters * args.global_batch_size,
@@ -1077,19 +1077,19 @@ def build_train_valid_test_data_iterators(
 
     if train_dataloader is not None:
         train_data_iterator = iter(train_dataloader) if dl_type == 'single' \
-            else iter(cyclic_iter(train_dataloader))
+                              else iter(cyclic_iter(train_dataloader))
     else:
         train_data_iterator = None
 
     if valid_dataloader is not None:
         valid_data_iterator = iter(valid_dataloader) if dl_type == 'single' \
-            else iter(cyclic_iter(valid_dataloader))
+                              else iter(cyclic_iter(valid_dataloader))
     else:
         valid_data_iterator = None
 
     if test_dataloader is not None:
         test_data_iterator = iter(test_dataloader) if dl_type == 'single' \
-            else iter(cyclic_iter(test_dataloader))
+                             else iter(cyclic_iter(test_dataloader))
     else:
         test_data_iterator = None
 

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -408,11 +408,10 @@ def setup_model_and_optimizer(model_provider_func,
         if state_dict is None:
             args.load = None
             set_args(args)
-
+    
     model = get_model(model_provider_func, model_type)
     unwrapped_model = unwrap_model(model,
                                    (torchDDP, LocalDDP, Float16Module))
-
     if args.load is not None:
         timers = get_timers()
         timers('load-checkpoint', log_level=0).start(barrier=True)

--- a/pretrain_multi_node.sh
+++ b/pretrain_multi_node.sh
@@ -3,7 +3,7 @@
 # Runs the "345M" parameter model
 
 source_folder="/mnt/pvc/checkpoints"
-target_folder="/mnt/checkpoints"
+target_folder="/workspace"
 latest_checkpoint_file="${source_folder}/latest_checkpointed_iteration.txt"
 
 if [ -f "$latest_checkpoint_file" ]; then
@@ -26,7 +26,7 @@ export CUDA_DEVICE_MAX_CONNECTIONS=1
 if [ "$1" == "--save-to-pvc" ]; then
     CHECKPOINT_PATH=/mnt/pvc/checkpoints
 else
-    CHECKPOINT_PATH=/mnt/checkpoints
+    CHECKPOINT_PATH=/workspace
 fi
 
 VOCAB_FILE=/mnt/pvc/megatron-dev-dataset/gpt2-vocab.json
@@ -89,8 +89,9 @@ torchrun $DISTRIBUTED_ARGS pretrain_gpt.py \
     $OUTPUT_ARGS \
     $LOG_ARGS \
     --distributed-backend nccl \
-    --use-tensorizer \
+    --timing-file=/mnt/pvc/logs.json \
     --save $CHECKPOINT_PATH \
     --load $CHECKPOINT_PATH \
+    --use-tensorizer \
     --seed=42
 


### PR DESCRIPTION
This PR introduces support for [Tensorizer](https://github.com/coreweave/tensorizer) which allows for fast(er) checkpoint saving and loading. The motivation behind this is to speed up the process of saving and loading model checkpoints.

- Tensorizer can be activated in the training process by supplying the `--use-tensorizer` flag.
- The model weight initialization had been rewritten in this PR as during loading, Megatron initialized model weights on GPU which used an incredible amount of resources. To fix this, Tensorizer's `no_init_or_tensor` function was used to initialize the model on the `meta` device to save resources during checkpoint loading.
- Benchmarking tools and scripts are provided from within this PR as well as the `--timing-file` flag which is used to record checkpoint saving and loading times to a file.
- The changes work by serializing and deserializing individual components of the model such as the model weights, optimizer weights, and gradient weights. The PR was also only tested on decoder-only transformer models so it may not work for other types of transformer models such as encoder-decoder transformers.
- Information that is necessary for recreating the training state is still saved as a PyTorch pickle. It might be interesting to investigate storing such information through JSON but the vast bulk of the loading/saving time is instead spent on weights related to training the model.
